### PR TITLE
Update path in _mask.pyx

### DIFF
--- a/PythonAPI/halpecocotools/_mask.pyx
+++ b/PythonAPI/halpecocotools/_mask.pyx
@@ -1,5 +1,5 @@
 # distutils: language = c
-# distutils: sources = ../common/maskApi.c
+# distutils: sources = common/maskApi.c
 
 #**************************************************************************
 # Microsoft COCO Toolbox.      version 2.0


### PR DESCRIPTION
Update path in _mask.pyx according to https://github.com/HaoyiZhu/HalpeCOCOAPI/issues/1 which allows to `git clone` or `git submodule` this package and build it using `pip install -e ./PythonAPI/`